### PR TITLE
Change vendor file publish tag

### DIFF
--- a/src/MonitoredJobsServiceProvider.php
+++ b/src/MonitoredJobsServiceProvider.php
@@ -48,7 +48,7 @@ class MonitoredJobsServiceProvider extends EventServiceProvider
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__.'/../config/config.php' => config_path('monitored-jobs.php'),
-            ], 'config');
+            ], 'monitored-jobs');
         }
     }
 


### PR DESCRIPTION
Currently the publish tag _monitored-jobs_ doesn't actually allow any any of the vendor files to be copied. You have to run it with the _config_ tag currently for it to publish the asset, which has the undesired side effect of also running any other package commands with the same identifier.

![image](https://user-images.githubusercontent.com/10764464/159899103-0d4207ec-16f8-41d9-aff9-037e1c9dcfca.png)

This change also keeps everything in line with the existing documentation, where it does suggest _monitored-jobs_ should work.

![image](https://user-images.githubusercontent.com/10764464/159898609-e4292471-d911-47b9-a008-47dd495c9b6e.png)
